### PR TITLE
fix: OOMKilled, CrashLoopBackOff, Memory limit, memory limit (backend/cmd/server/main.go)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -308,7 +308,15 @@ func (app *App) startOOMSimulation() {
 	go func() {
 		for {
 			app.mu.Lock()
-			// Allocate 10MB chunks
+			if len(app.memoryLeak) >= 10 {
+				app.mu.Unlock()
+				app.log("warn", "OOM simulation reached max chunks, skipping allocation", map[string]interface{}{
+					"chunks":  len(app.memoryLeak),
+					"size_mb": len(app.memoryLeak) * 10,
+				})
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)
@@ -336,6 +344,15 @@ func (app *App) startBuggyCacheWarmup() {
 	go func() {
 		for {
 			app.mu.Lock()
+			if len(app.memoryLeak) >= 10 {
+				app.mu.Unlock()
+				app.log("warn", "Cache warmup reached max chunks, skipping allocation", map[string]interface{}{
+					"chunks":  len(app.memoryLeak),
+					"size_mb": len(app.memoryLeak) * 10,
+				})
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)


### PR DESCRIPTION
## Summary
Automated fix for error in `backend/cmd/server/main.go:324`.

## Error
```
OOMKilled, CrashLoopBackOff, Memory limit, memory limit
```

## Explanation
Bounded the intentional memory leak in startOOMSimulation and startBuggyCacheWarmup by capping the number of 10MB chunks stored, preventing unbounded growth that led to OOMKilled and CrashLoopBackOff while preserving the simulation behavior.


## Runtime Correlation
- Cluster: `k3d-kubeiq-test-cluster`
- Namespace: `demo`
- Workload: `Deployment/payflow-backend`

---
Generated by InfraSage Agent | Content hash: `d8255798bbd4375b`
