### PR TITLE
fix: OOMKilled, CrashLoopBackOff, exit code 137, memory limit (backend/cmd/server/main.go)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -306,9 +306,14 @@ func (app *App) startOOMSimulation() {
 	}
 	app.log("warn", "OOM simulation enabled - memory will grow", nil)
 	go func() {
+		maxChunks := 10
 		for {
 			app.mu.Lock()
-			// Allocate 10MB chunks
+			if len(app.memoryLeak) >= maxChunks {
+				app.mu.Unlock()
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)
@@ -321,7 +326,7 @@ func (app *App) startOOMSimulation() {
 			})
 			time.Sleep(5 * time.Second)
 		}
-	}()
+	}() 
 }
 
 func (app *App) startBuggyCacheWarmup() {
@@ -334,8 +339,14 @@ func (app *App) startBuggyCacheWarmup() {
 	})
 
 	go func() {
+		maxChunks := 10
 		for {
 			app.mu.Lock()
+			if len(app.memoryLeak) >= maxChunks {
+				app.mu.Unlock()
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)


### PR DESCRIPTION
## Summary
Automated fix for error in `backend/cmd/server/main.go:324`.

## Error
```
OOMKilled, CrashLoopBackOff, exit code 137, memory limit
```

## Explanation
Bound the memory growth in both the OOM simulation and buggy cache warmup goroutines by capping the number of 10MB chunks stored, preventing unbounded memory usage that caused OOMKilled (exit code 137).


## Runtime Correlation
- Cluster: `k3d-kubeiq-test-cluster`
- Namespace: `demo`
- Workload: `Deployment/payflow-backend`

---
Generated by InfraSage Agent | Content hash: `bcdbf4ecd4830516`
