### PR TITLE
fix: OOMKilled, CrashLoopBackOff, exit code 137, memory limit, me (backend/cmd/server/main.go)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -304,11 +304,20 @@ func (app *App) startOOMSimulation() {
 	if !app.config.InjectOOM {
 		return
 	}
-	app.log("warn", "OOM simulation enabled - memory will grow", nil)
+	app.log("warn", "OOM simulation enabled - memory will grow (capped)", nil)
 	go func() {
+		maxChunks := 10
 		for {
 			app.mu.Lock()
-			// Allocate 10MB chunks
+			if len(app.memoryLeak) >= maxChunks {
+				app.mu.Unlock()
+				app.log("warn", "OOM simulation reached cap, skipping allocation", map[string]interface{}{
+					"chunks":  len(app.memoryLeak),
+					"size_mb": len(app.memoryLeak) * 10,
+				})
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)
@@ -329,13 +338,23 @@ func (app *App) startBuggyCacheWarmup() {
 		return
 	}
 
-	app.log("warn", "New cache enabled - warming cache (buggy)", map[string]interface{}{
+	app.log("warn", "New cache enabled - warming cache (buggy, capped)", map[string]interface{}{
 		"cache_max_size": app.config.CacheMaxSize,
 	})
 
 	go func() {
+		maxChunks := 10
 		for {
 			app.mu.Lock()
+			if len(app.memoryLeak) >= maxChunks {
+				app.mu.Unlock()
+				app.log("warn", "Cache warmup reached cap, skipping allocation", map[string]interface{}{
+					"chunks":  len(app.memoryLeak),
+					"size_mb": len(app.memoryLeak) * 10,
+				})
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)


### PR DESCRIPTION
## Summary
Automated fix for error in `backend/cmd/server/main.go:324`.

## Error
```
OOMKilled, CrashLoopBackOff, exit code 137, memory limit, memory allocation
```

## Explanation
Both OOM simulation goroutines were allocating unbounded 10MB chunks into app.memoryLeak, causing the process to exceed its memory limit and be OOMKilled. Added a simple cap (maxChunks := 10) with a check before allocation in startOOMSimulation and startBuggyCacheWarmup so memory growth is bounded while preserving the existing behavior and structure.


## Runtime Correlation
- Cluster: `k3d-kubeiq-test-cluster`
- Namespace: `demo`
- Workload: `Deployment/payflow-backend`

---
Generated by InfraSage Agent | Content hash: `9e46098de7383329`
