### PR TITLE
fix: OOMKilled, CrashLoopBackOff, Exit Code 137, Memory limit, me (backend/cmd/server/main.go)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -306,9 +306,14 @@ func (app *App) startOOMSimulation() {
 	}
 	app.log("warn", "OOM simulation enabled - memory will grow", nil)
 	go func() {
+		maxChunks := 50
 		for {
 			app.mu.Lock()
-			// Allocate 10MB chunks
+			if len(app.memoryLeak) >= maxChunks {
+				app.mu.Unlock()
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)
@@ -321,7 +326,7 @@ func (app *App) startOOMSimulation() {
 			})
 			time.Sleep(5 * time.Second)
 		}
-	}()
+	}() 
 }
 
 func (app *App) startBuggyCacheWarmup() {
@@ -334,8 +339,14 @@ func (app *App) startBuggyCacheWarmup() {
 	})
 
 	go func() {
+		maxChunks := 50
 		for {
 			app.mu.Lock()
+			if len(app.memoryLeak) >= maxChunks {
+				app.mu.Unlock()
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)


### PR DESCRIPTION
## Summary
Automated fix for error in `backend/cmd/server/main.go:324`.

## Error
```
OOMKilled, CrashLoopBackOff, Exit Code 137, Memory limit, memory limit
```

## Explanation
Limited the unbounded memory growth in both OOM simulation and buggy cache warmup by capping the number of stored 10MB chunks, preventing the process from being OOMKilled while preserving behavior characteristics.


## Runtime Correlation
- Cluster: `k3d-kubeiq-test-cluster`
- Namespace: `demo`
- Workload: `Deployment/payflow-backend-7658c7c778-b96qm**\n\n|`

---
Generated by InfraSage Agent | Content hash: `b88496bbad372e7e`
