### PR TITLE
fix: OOMKilled, CrashLoopBackOff, exit code 137, Memory limit, me (backend/cmd/server/main.go)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -304,20 +304,26 @@ func (app *App) startOOMSimulation() {
 	if !app.config.InjectOOM {
 		return
 	}
-	app.log("warn", "OOM simulation enabled - memory will grow", nil)
+	app.log("warn", "OOM simulation enabled - capped memory growth", nil)
 	go func() {
+		maxChunks := 5
 		for {
 			app.mu.Lock()
-			// Allocate 10MB chunks
+			if len(app.memoryLeak) >= maxChunks {
+				app.mu.Unlock()
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)
 			}
 			app.memoryLeak = append(app.memoryLeak, chunk)
+			currentChunks := len(app.memoryLeak)
 			app.mu.Unlock()
 			app.log("warn", "Memory allocated", map[string]interface{}{
-				"chunks": len(app.memoryLeak),
-				"size_mb": len(app.memoryLeak) * 10,
+				"chunks":  currentChunks,
+				"size_mb": currentChunks * 10,
 			})
 			time.Sleep(5 * time.Second)
 		}
@@ -329,23 +335,30 @@ func (app *App) startBuggyCacheWarmup() {
 		return
 	}
 
-	app.log("warn", "New cache enabled - warming cache (buggy)", map[string]interface{}{
+	app.log("warn", "New cache enabled - warming cache (capped)", map[string]interface{}{
 		"cache_max_size": app.config.CacheMaxSize,
 	})
 
 	go func() {
+		maxChunks := 5
 		for {
 			app.mu.Lock()
+			if len(app.memoryLeak) >= maxChunks {
+				app.mu.Unlock()
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)
 			}
 			app.memoryLeak = append(app.memoryLeak, chunk)
+			currentChunks := len(app.memoryLeak)
 			app.mu.Unlock()
 
 			app.log("warn", "Cache warmup allocated", map[string]interface{}{
-				"chunks":  len(app.memoryLeak),
-				"size_mb": len(app.memoryLeak) * 10,
+				"chunks":  currentChunks,
+				"size_mb": currentChunks * 10,
 			})
 			time.Sleep(5 * time.Second)
 		}


### PR DESCRIPTION
## Summary
Automated fix for error in `backend/cmd/server/main.go:324`.

## Error
```
OOMKilled, CrashLoopBackOff, exit code 137, Memory limit, memoryLeak, memory leak, memory limit
```

## Explanation
Capped the unbounded memory growth in both OOM simulation and buggy cache warmup by limiting the number of 10MB chunks stored in memory, preventing the process from exceeding the memory limit and being OOMKilled, while keeping the allocation behavior for testing purposes.


## Runtime Correlation
- Cluster: `k3d-kubeiq-test-cluster`
- Namespace: `demo`
- Workload: `Deployment/payflow-backend`

---
Generated by InfraSage Agent | Content hash: `b7af0fe77d294ae4`
