### PR TITLE
fix: OOMKilled, CrashLoopBackOff, memory limit (backend/cmd/server/main.go)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -329,13 +329,24 @@ func (app *App) startBuggyCacheWarmup() {
 		return
 	}
 
-	app.log("warn", "New cache enabled - warming cache (buggy)", map[string]interface{}{
+	app.log("warn", "New cache enabled - warming cache (capped)", map[string]interface{}{
 		"cache_max_size": app.config.CacheMaxSize,
 	})
+
+	const maxChunks = 5
 
 	go func() {
 		for {
 			app.mu.Lock()
+			if len(app.memoryLeak) >= maxChunks {
+				app.mu.Unlock()
+				app.log("warn", "Cache warmup limit reached", map[string]interface{}{
+					"chunks":  len(app.memoryLeak),
+					"size_mb": len(app.memoryLeak) * 10,
+				})
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			chunk := make([]byte, 10*1024*1024)
 			for i := range chunk {
 				chunk[i] = byte(i % 256)


### PR DESCRIPTION
## Summary
Automated fix for error in `backend/cmd/server/main.go:332`.

## Error
```
OOMKilled, CrashLoopBackOff, memory limit
```

## Explanation
Capped the buggy cache warmup goroutine so it stops allocating new 10MB chunks after a small fixed limit, preventing unbounded memory growth that caused OOMKilled while preserving existing behavior up to that cap.


## Runtime Correlation
- Cluster: `k3d-kubeiq-test-cluster`
- Namespace: `demo`
- Workload: `Deployment/payflow-backend`

---
Generated by InfraSage Agent | Content hash: `33335681adfa2e71`
